### PR TITLE
feat(css): change localIdentName

### DIFF
--- a/packages/css/index.js
+++ b/packages/css/index.js
@@ -7,7 +7,7 @@ module.exports = () => ({
   modifyWebpackConfig({env: {target, dev: isDev}, webpackConfig}) {
     const isServer = target === 'node'
 
-    const localIdentName = isDev ? '[path]__[name]__[local]' : '[contenthash:base64:8]'
+    const localIdentName = isDev ? '[path][name]__[local]' : '[contenthash:base64:8]'
 
     let loaders
     let vendorCSSLoaders

--- a/packages/css/index.js
+++ b/packages/css/index.js
@@ -7,7 +7,7 @@ module.exports = () => ({
   modifyWebpackConfig({env: {target, dev: isDev}, webpackConfig}) {
     const isServer = target === 'node'
 
-    const localIdentName = isDev ? '[path][local]' : '[contenthash:base64:8]'
+    const localIdentName = isDev ? '[path]__[name]__[local]' : '[contenthash:base64:8]'
 
     let loaders
     let vendorCSSLoaders


### PR DESCRIPTION
Поправил `localIdentName` для dev разработки

Есть проблема, что если файлы стилей лежат на одном уровне и, например, в каждом файле есть класс с идентичным названием, то стили будут накладываться друг на друга, т.к. путь  у них одинаковый
<img width="675" alt="Снимок экрана 2024-07-08 в 14 19 12" src="https://github.com/rambler-digital-solutions/razzle-addons/assets/55979609/74f3dab4-f7c4-4461-a263-1f5a8279503d">

Предлагаю добавить `[name]` (имя файла) к `localIdentName` чтобы путь был более уникальным
<img width="677" alt="Снимок экрана 2024-07-08 в 14 15 09" src="https://github.com/rambler-digital-solutions/razzle-addons/assets/55979609/5a1819ae-0a5d-41ad-8a68-51db1487a61e">


